### PR TITLE
Upgrade rquickjs to 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 node_modules/
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra"
 description = "Extra modules for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -19,11 +19,11 @@ console = ["rquickjs-extra-console"]
 sqlite = ["rquickjs-extra-sqlite"]
 
 [dependencies]
-rquickjs-extra-console = { version = "0.1.1", path = "modules/console", optional = true }
-rquickjs-extra-os = { version = "0.1.1", path = "modules/os", optional = true }
-rquickjs-extra-sqlite = { version = "0.1.1", path = "modules/sqlite", optional = true }
-rquickjs-extra-timers = { version = "0.1.1", path = "modules/timers", optional = true }
-rquickjs-extra-url = { version = "0.1.1", path = "modules/url", optional = true }
+rquickjs-extra-console = { version = "0.1.2", path = "modules/console", optional = true }
+rquickjs-extra-os = { version = "0.1.2", path = "modules/os", optional = true }
+rquickjs-extra-sqlite = { version = "0.1.2", path = "modules/sqlite", optional = true }
+rquickjs-extra-timers = { version = "0.1.2", path = "modules/timers", optional = true }
+rquickjs-extra-url = { version = "0.1.2", path = "modules/url", optional = true }
 
 [workspace]
 resolver = "2"

--- a/libs/test/Cargo.toml
+++ b/libs/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra-test"
 description = "Test library for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -9,5 +9,5 @@ authors = ["Emile Fugulin <code@efugulin.com>"]
 
 [dependencies]
 futures = { version = "0.3" }
-rquickjs = { version = "0.9", features = ["macro", "futures"] }
+rquickjs = { version = "0.10.0", features = ["macro", "futures"] }
 tokio = { version = "1", features = ["full"] }

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rquickjs-extra-utils"
 description = "Utils library for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
 authors = ["Emile Fugulin <code@efugulin.com>"]
 
 [dependencies]
-rquickjs = { version = "0.9", features = ["array-buffer"] }
+rquickjs = { version = "0.10.0", features = ["array-buffer"] }

--- a/modules/console/Cargo.toml
+++ b/modules/console/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra-console"
 description = "Console module for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -9,7 +9,7 @@ authors = ["Emile Fugulin <code@efugulin.com>"]
 
 [dependencies]
 log = { version = "0.4" }
-rquickjs = { version = "0.9", features = ["macro"] }
+rquickjs = { version = "0.10.0", features = ["macro"] }
 
 [dev-dependencies]
 rquickjs-extra-test = { path = "../../libs/test" }

--- a/modules/os/Cargo.toml
+++ b/modules/os/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra-os"
 description = "OS module for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -11,8 +11,8 @@ authors = ["Emile Fugulin <code@efugulin.com>"]
 home = "0.5"
 num_cpus = "1"
 once_cell = "1"
-rquickjs = { version = "0.9", features = ["macro"] }
-rquickjs-extra-utils = { version = "0.1.1", path = "../../libs/utils" }
+rquickjs = { version = "0.10.0", features = ["macro"] }
+rquickjs-extra-utils = { version = "0.1.2", path = "../../libs/utils" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -23,6 +23,6 @@ windows-result = "0.3"
 windows-version = "0.1"
 
 [dev-dependencies]
-rquickjs = { version = "0.9", features = ["futures"] }
+rquickjs = { version = "0.10.0", features = ["futures"] }
 rquickjs-extra-test = { path = "../../libs/test" }
 tokio = { version = "1", features = ["full"] }

--- a/modules/sqlite/Cargo.toml
+++ b/modules/sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra-sqlite"
 description = "SQLite module for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -9,13 +9,13 @@ authors = ["Emile Fugulin <code@efugulin.com>"]
 
 [dependencies]
 either = { version = "1" }
-rquickjs = { version = "0.9", features = [
+rquickjs = { version = "0.10.0", features = [
   "array-buffer",
   "either",
   "macro",
   "futures",
 ] }
-rquickjs-extra-utils = { version = "0.1.1", path = "../../libs/utils" }
+rquickjs-extra-utils = { version = "0.1.2", path = "../../libs/utils" }
 sqlx = { version = "0.8", default-features = false, features = [
   "sqlite",
   "runtime-tokio",

--- a/modules/timers/Cargo.toml
+++ b/modules/timers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra-timers"
 description = "Timers module for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -9,7 +9,7 @@ authors = ["Emile Fugulin <code@efugulin.com>"]
 
 [dependencies]
 log = { version = "0.4" }
-rquickjs = { version = "0.9", features = ["macro", "futures"] }
+rquickjs = { version = "0.10.0", features = ["macro", "futures"] }
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 
 [dev-dependencies]

--- a/modules/url/Cargo.toml
+++ b/modules/url/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquickjs-extra-url"
 description = "URL module for RQuickJS"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rquickjs/rquickjs-extra"
@@ -9,7 +9,7 @@ authors = ["Emile Fugulin <code@efugulin.com>"]
 
 [dependencies]
 either = { version = "1" }
-rquickjs = { version = "0.9", features = ["either", "macro"] }
+rquickjs = { version = "0.10.0", features = ["either", "macro"] }
 
 [dev-dependencies]
 rquickjs-extra-test = { path = "../../libs/test" }


### PR DESCRIPTION
Hello there! Thanks a lot for the repo.

Usages of both rquickjs 0.9.0 and 0.10.0 cause issues and this upgrade helps.
Happy to apply other adjustments if needed, e.g. to use `0.2.0` vs `0.1.2` if you prefer.